### PR TITLE
Fix jsonb queries

### DIFF
--- a/src/lib/jsonresume.server.ts
+++ b/src/lib/jsonresume.server.ts
@@ -103,7 +103,7 @@ export async function updateResumeData(
   ] = await Promise.all([
     db
       .selectFrom("records_basics")
-      .select((q) => q.ref("record", "->>").key("createdAt").as("createdAt"))
+      .select((q) => q.ref("record", "->").key("createdAt").as("createdAt"))
       .where("did", "=", did)
       .executeTakeFirst(),
     db

--- a/src/lib/profile.server.ts
+++ b/src/lib/profile.server.ts
@@ -28,10 +28,10 @@ export async function loadProfile(
   const profile = await db
     .selectFrom("records_profile")
     .select((query) => [
-      query.ref("record", "->>").key("name").as("name"),
-      query.ref("record", "->>").key("title").as("title"),
-      query.ref("record", "->>").key("introduction").as("introduction"),
-      query.ref("record", "->>").key("countryCode").as("country_code"),
+      query.ref("record", "->").key("name").as("name"),
+      query.ref("record", "->").key("title").as("title"),
+      query.ref("record", "->").key("introduction").as("introduction"),
+      query.ref("record", "->").key("countryCode").as("country_code"),
     ])
     .where("did", "=", did)
     .executeTakeFirst();
@@ -97,14 +97,14 @@ export async function updateProfileData(
   const [profile, basics] = await Promise.all([
     db
       .selectFrom("records_profile")
-      .select((q) => q.ref("record", "->>").key("createdAt").as("createdAt"))
+      .select((q) => q.ref("record", "->").key("createdAt").as("createdAt"))
       .where("did", "=", did)
       .executeTakeFirst(),
     db
       .selectFrom("records_basics")
       .select((q) => [
-        q.ref("record", "->>").key("about").as("about"),
-        q.ref("record", "->>").key("createdAt").as("createdAt"),
+        q.ref("record", "->").key("about").as("about"),
+        q.ref("record", "->").key("createdAt").as("createdAt"),
       ])
       .where("did", "=", did)
       .executeTakeFirst(),
@@ -151,7 +151,7 @@ export async function loadProfileContacts(did: DidString) {
     .selectFrom("records_account")
     .select((query) => [
       "rkey",
-      query.ref("record", "->>").key("url").as("url"),
+      query.ref("record", "->").key("url").as("url"),
     ])
     .where("did", "=", did)
     .execute();

--- a/src/lib/recommendation.remote.ts
+++ b/src/lib/recommendation.remote.ts
@@ -37,9 +37,9 @@ export const getProfileRecommendations = query(
         "rec.uri",
         "rec.did as author_did",
         "author_id.handle as author_handle",
-        query.ref("author.record", "->>").key("name").as("author_name"),
-        query.ref("rec.record", "->>").key("reason").as("reason"),
-        query.ref("rec.record", "->>").key("createdAt").as("created_at"),
+        query.ref("author.record", "->").key("name").as("author_name"),
+        query.ref("rec.record", "->").key("reason").as("reason"),
+        query.ref("rec.record", "->").key("createdAt").as("created_at"),
       ])
       .execute();
 

--- a/src/lib/resume.server.ts
+++ b/src/lib/resume.server.ts
@@ -35,18 +35,18 @@ export async function loadResumeBasicsData(
     db
       .selectFrom("records_profile")
       .select((q) => [
-        q.ref("record", "->>").key("name").as("name"),
-        q.ref("record", "->>").key("title").as("title"),
-        q.ref("record", "->>").key("countryCode").as("countryCode"),
+        q.ref("record", "->").key("name").as("name"),
+        q.ref("record", "->").key("title").as("title"),
+        q.ref("record", "->").key("countryCode").as("countryCode"),
       ])
       .where("did", "=", did)
       .executeTakeFirst(),
     db
       .selectFrom("records_basics")
       .select((q) => [
-        q.ref("record", "->>").key("about").as("about"),
+        q.ref("record", "->").key("about").as("about"),
         q
-          .ref("record", "->>")
+          .ref("record", "->")
           .key("preferredWorkplace")
           .as("preferredWorkplace"),
       ])
@@ -116,14 +116,14 @@ export async function updateResumeBasicsData(
     db
       .selectFrom("records_profile")
       .select((q) => [
-        q.ref("record", "->>").key("introduction").as("introduction"),
-        q.ref("record", "->>").key("createdAt").as("createdAt"),
+        q.ref("record", "->").key("introduction").as("introduction"),
+        q.ref("record", "->").key("createdAt").as("createdAt"),
       ])
       .where("did", "=", did)
       .executeTakeFirst(),
     db
       .selectFrom("records_basics")
-      .select((q) => q.ref("record", "->>").key("createdAt").as("createdAt"))
+      .select((q) => q.ref("record", "->").key("createdAt").as("createdAt"))
       .where("did", "=", did)
       .executeTakeFirst(),
   ]);
@@ -172,7 +172,7 @@ export async function loadResumeLanguagesData(did: DidString) {
   const db = await getDB();
   const languages = await db
     .selectFrom("records_language")
-    .select((q) => ["rkey", q.ref("record", "->>").key("name").as("name")])
+    .select((q) => ["rkey", q.ref("record", "->").key("name").as("name")])
     .where("did", "=", did)
     .execute();
   return languages;
@@ -224,7 +224,7 @@ export async function loadResumeSkillsData(did: DidString) {
   const db = await getDB();
   const skills = await db
     .selectFrom("records_skill")
-    .select((q) => ["rkey", q.ref("record", "->>").key("name").as("name")])
+    .select((q) => ["rkey", q.ref("record", "->").key("name").as("name")])
     .where("did", "=", did)
     .execute();
   return skills;

--- a/src/lib/sifa.server.ts
+++ b/src/lib/sifa.server.ts
@@ -83,9 +83,9 @@ export async function loadSifaResume(
     db
       .selectFrom("records_profile")
       .select((q) => [
-        q.ref("record", "->>").key("name").as("name"),
-        q.ref("record", "->>").key("title").as("title"),
-        q.ref("record", "->>").key("countryCode").as("countryCode"),
+        q.ref("record", "->").key("name").as("name"),
+        q.ref("record", "->").key("title").as("title"),
+        q.ref("record", "->").key("countryCode").as("countryCode"),
       ])
       .where("did", "=", did)
       .executeTakeFirst(),
@@ -93,13 +93,13 @@ export async function loadSifaResume(
     db
       .selectFrom("records_basics")
       .select((q) => [
-        q.ref("record", "->>").key("about").as("about"),
-        q.ref("record", "->>").key("industry").as("industry"),
+        q.ref("record", "->").key("about").as("about"),
+        q.ref("record", "->").key("industry").as("industry"),
         q
-          .ref("record", "->>")
+          .ref("record", "->")
           .key("preferredWorkplace")
           .as("preferredWorkplace"),
-        q.ref("record", "->>").key("location").as("location"),
+        q.ref("record", "->").key("location").as("location"),
       ])
       .where("did", "=", did)
       .executeTakeFirst(),
@@ -107,14 +107,14 @@ export async function loadSifaResume(
     db
       .selectFrom("records_position")
       .select((q) => [
-        q.ref("record", "->>").key("company").as("company"),
-        q.ref("record", "->>").key("title").as("title"),
-        q.ref("record", "->>").key("description").as("description"),
-        q.ref("record", "->>").key("startedAt").as("startedAt"),
-        q.ref("record", "->>").key("endedAt").as("endedAt"),
-        q.ref("record", "->>").key("employmentType").as("employmentType"),
-        q.ref("record", "->>").key("workplaceType").as("workplaceType"),
-        q.ref("record", "->>").key("location").as("location"),
+        q.ref("record", "->").key("company").as("company"),
+        q.ref("record", "->").key("title").as("title"),
+        q.ref("record", "->").key("description").as("description"),
+        q.ref("record", "->").key("startedAt").as("startedAt"),
+        q.ref("record", "->").key("endedAt").as("endedAt"),
+        q.ref("record", "->").key("employmentType").as("employmentType"),
+        q.ref("record", "->").key("workplaceType").as("workplaceType"),
+        q.ref("record", "->").key("location").as("location"),
       ])
       .where("did", "=", did)
       .orderBy((q) => q.ref("record", "->>").key("startedAt"), "desc")
@@ -123,12 +123,12 @@ export async function loadSifaResume(
     db
       .selectFrom("records_education")
       .select((q) => [
-        q.ref("record", "->>").key("institution").as("institution"),
-        q.ref("record", "->>").key("degree").as("degree"),
-        q.ref("record", "->>").key("fieldOfStudy").as("fieldOfStudy"),
-        q.ref("record", "->>").key("startedAt").as("startedAt"),
-        q.ref("record", "->>").key("endedAt").as("endedAt"),
-        q.ref("record", "->>").key("description").as("description"),
+        q.ref("record", "->").key("institution").as("institution"),
+        q.ref("record", "->").key("degree").as("degree"),
+        q.ref("record", "->").key("fieldOfStudy").as("fieldOfStudy"),
+        q.ref("record", "->").key("startedAt").as("startedAt"),
+        q.ref("record", "->").key("endedAt").as("endedAt"),
+        q.ref("record", "->").key("description").as("description"),
       ])
       .where("did", "=", did)
       .orderBy((q) => q.ref("record", "->>").key("startedAt"), "desc")
@@ -136,18 +136,18 @@ export async function loadSifaResume(
 
     db
       .selectFrom("records_skill")
-      .select((q) => [q.ref("record", "->>").key("name").as("name")])
+      .select((q) => [q.ref("record", "->").key("name").as("name")])
       .where("did", "=", did)
       .execute(),
 
     db
       .selectFrom("records_project")
       .select((q) => [
-        q.ref("record", "->>").key("name").as("name"),
-        q.ref("record", "->>").key("description").as("description"),
-        q.ref("record", "->>").key("url").as("url"),
-        q.ref("record", "->>").key("startedAt").as("startedAt"),
-        q.ref("record", "->>").key("endedAt").as("endedAt"),
+        q.ref("record", "->").key("name").as("name"),
+        q.ref("record", "->").key("description").as("description"),
+        q.ref("record", "->").key("url").as("url"),
+        q.ref("record", "->").key("startedAt").as("startedAt"),
+        q.ref("record", "->").key("endedAt").as("endedAt"),
       ])
       .where("did", "=", did)
       .orderBy((q) => q.ref("record", "->>").key("startedAt"), "desc")
@@ -155,15 +155,15 @@ export async function loadSifaResume(
 
     db
       .selectFrom("records_language")
-      .select((q) => [q.ref("record", "->>").key("name").as("name")])
+      .select((q) => [q.ref("record", "->").key("name").as("name")])
       .where("did", "=", did)
       .execute(),
 
     db
       .selectFrom("records_account")
       .select((q) => [
-        q.ref("record", "->>").key("url").as("url"),
-        q.ref("record", "->>").key("isPrimary").as("isPrimary"),
+        q.ref("record", "->").key("url").as("url"),
+        q.ref("record", "->").key("isPrimary").as("isPrimary"),
       ])
       .where("did", "=", did)
       .execute(),

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -13,9 +13,9 @@ export const load = async ({ locals }) => {
       "rec.uri",
       "rec.did as author_did",
       "author_id.handle as author_handle",
-      query.ref("author.record", "->>").key("name").as("author_name"),
-      query.ref("rec.record", "->>").key("reason").as("reason"),
-      query.ref("rec.record", "->>").key("createdAt").as("created_at"),
+      query.ref("author.record", "->").key("name").as("author_name"),
+      query.ref("rec.record", "->").key("reason").as("reason"),
+      query.ref("rec.record", "->").key("createdAt").as("created_at"),
     ])
     .limit(4)
     .execute();

--- a/src/routes/auth/callback/+server.ts
+++ b/src/routes/auth/callback/+server.ts
@@ -34,9 +34,9 @@ async function ensureProfile(
       .selectFrom("records_basics")
       .where("did", "=", did)
       .select((q) => [
-        q.ref("record", "->>").key("headline").as("headline"),
-        q.ref("record", "->>").key("about").as("about"),
-        q.ref("record", "->>").key("location").as("location"),
+        q.ref("record", "->").key("headline").as("headline"),
+        q.ref("record", "->").key("about").as("about"),
+        q.ref("record", "->").key("location").as("location"),
       ])
       .executeTakeFirst(),
   ]);

--- a/src/routes/feed/+page.server.ts
+++ b/src/routes/feed/+page.server.ts
@@ -56,13 +56,13 @@ export const load = async ({ locals }) => {
       // author
       "rec.did as author_did",
       "author_id.handle as author_handle",
-      q.ref("author.record", "->>").key("name").as("author_name"),
+      q.ref("author.record", "->").key("name").as("author_name"),
       // subject
-      q.ref("rec.record", "->>").key("subject").as("subject_did"),
+      q.ref("rec.record", "->").key("subject").as("subject_did"),
       "subject_id.handle as subject_handle",
-      q.ref("subject.record", "->>").key("name").as("subject_name"),
-      q.ref("rec.record", "->>").key("reason").as("reason"),
-      q.ref("rec.record", "->>").key("createdAt").as("created_at"),
+      q.ref("subject.record", "->").key("name").as("subject_name"),
+      q.ref("rec.record", "->").key("reason").as("reason"),
+      q.ref("rec.record", "->").key("createdAt").as("created_at"),
     ])
     .execute();
 
@@ -73,9 +73,9 @@ export const load = async ({ locals }) => {
     .select((q) => [
       "records_profile.did",
       "identities.handle",
-      q.ref("record", "->>").key("name").as("name"),
-      q.ref("record", "->>").key("introduction").as("introduction"),
-      q.ref("record", "->>").key("createdAt").as("created_at"),
+      q.ref("record", "->").key("name").as("name"),
+      q.ref("record", "->").key("introduction").as("introduction"),
+      q.ref("record", "->").key("createdAt").as("created_at"),
     ])
     .orderBy(
       (q) => q.ref("records_profile.record", "->>").key("createdAt"),


### PR DESCRIPTION
So ->> returns serialized json. Then in case of arrays or literals the result is always is string. -> operator solves this by returning parsed result. Though it should not be used in order, where, join etc clauses, only in select.